### PR TITLE
Fix spectrogram typo in card

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,7 +47,7 @@
       <div class="col-md-4 col-sm-6">
         <div class="card h-100">
           <div class="card-body">
-            <h5 class="card-title">Sepctrogram</h5>
+            <h5 class="card-title">Spectrogram</h5>
             <p class="card-text">A simple spectrogram.</p>
             <a href="https://i-tabu.github.io/spectrogram" class="btn btn-primary" target="_blank">Visit Tool</a>
           </div>


### PR DESCRIPTION
## Summary
- fix misspelled "Sepctrogram" in index page

## Testing
- `grep -n Spectrogram -n index.html`

------
https://chatgpt.com/codex/tasks/task_e_6846d99d4a388323972d9a09b4f4b5e2